### PR TITLE
Support build params for global var

### DIFF
--- a/ice.config.js
+++ b/ice.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const WebpackPluginDefine = require("webpack").DefinePlugin;
+
 
 module.exports = {
   entry: 'src/index.jsx',
@@ -20,4 +22,16 @@ module.exports = {
   alias: {
     '@': path.resolve(__dirname, './src/'),
   },
+  chainWebpack: (config) => {
+    config
+      // 定义插件名称
+      .plugin('WebpackPluginDefine')
+      // 第一项为具体插件，第二项为插件参数
+      .use(WebpackPluginDefine, [
+        {
+          QKC_JRPC: JSON.stringify(process.env.QKC_JRPC) || "'http://jrpc.devnet.quarkchain.io:38391'",
+          QKC_EXPLORER: JSON.stringify(process.env.QKC_EXPLORER) || "'https://devnet.quarkchain.io/'",
+        },
+      ]);
+  }
 };

--- a/src/utils/global.js
+++ b/src/utils/global.js
@@ -5,8 +5,8 @@ import QuarkChain from 'quarkchain-web3-beta';
 import BigNumber from 'bignumber.js';
 import * as Contracts from './contracts';
 
-export const QuarkChainNetwork = 'https://devnet.quarkchain.io/';
-export const QuarkChainRPC = 'http://jrpc.devnet.quarkchain.io:38391';
+export const QuarkChainNetwork = QKC_EXPLORER;
+export const QuarkChainRPC = QKC_JRPC;
 export const InvalidAddr = '0x0000000000000000000000000000000000000000';
 export const MetamaskErrorInfo = 'Please check whether MetaMask has been installed and login, or whether the website has been added to the trusted connections of MetaMask.';
 


### PR DESCRIPTION
so building with different network parameters can be done as

```bash
QKC_EXPLORER=https://mainnet.quarkchain.io/ \
QKC_JRPC=http://jrpc.mainnet.quarkchain.io:38391 \
  npm run build
```